### PR TITLE
Hook should exit on pydocstyle failure

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -144,7 +144,7 @@ if [ "$8" = true ] ; then
         echo "pydocstyle ok"
     else
         echo "pydocstyle error"
-        echo $exit_code
+        exit $exit_code
     fi
 fi
 


### PR DESCRIPTION
Hello Weibullguy! Thanks for the awesome github action! I noticed pydocstyle doesn't exit but echos when it fails and I didn't see anywhere to open issues. So I thought I might make a PR which more strongly enforces pydocstyle. If this is undesirable, let me know I'd love to add a flag to make it possible to fail commits if not documented.  Thanks for the great repository!