### PR TITLE
Added docstring to init to pass pydoctest

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for all style checks."""


### PR DESCRIPTION
Sorry, I noticed in the last PR now the action fails on master because an init was missing a docstring. I added one to get the action passing on master! Thanks for the great repository!